### PR TITLE
Multiple metrics ports added to support more than one tunnel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="flask_cloudflared",
-    version="0.0.10",
+    version="0.0.11",
     author="Ralf Rademacher",
     description="Start a TryCloudflare Tunnel from your flask app.",
     long_description=long_description,


### PR DESCRIPTION
This updates the metrics port to take a random port, before it wasn't possible to run multiple instances of Trycloudflared at the same time.