### PR TITLE
added option to change metrics_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Start a [TryCloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/trycloudflare) tunnel to your flask app right from code.  
 This requires at least `Python 3.6`
 
+## Behavior
+The Flask app will run on port 5000 by default and start the Cloudflared metrics page on a random port between 8100 and 9000.  
+This can be changed by passing the `port` and `metrics_port` arguments to the `app.run()` function after using the `run_with_cloudflared` decorator.
+
 ### Users on Apple Silicon
 Because [cloudflared](https://github.com/cloudflare/cloudflared) doesn't support Darwin arm64 natively yet, Rosetta 2 is used to create a compatibility layer. If you don't have Rosetta 2 installed yet, please check [Apple's support page](https://support.apple.com/en-us/HT211861).
 

--- a/examples/flask_cloudflared_example.py
+++ b/examples/flask_cloudflared_example.py
@@ -9,4 +9,5 @@ def home():
     return "Hello World!" # Serve Hello World
 
 if __name__ == '__main__':
+    # app.run(port=1337, metrics_port=1338) # Run the app on port 1337 and metrics on port 1338
     app.run()

--- a/flask_cloudflared.py
+++ b/flask_cloudflared.py
@@ -140,10 +140,16 @@ def run_with_cloudflared(app):
     old_run = app.run
 
     def new_run(*args, **kwargs):
+        # Webserver port is 5000 by default.
         port = kwargs.get('port', 5000)
-        metrics_port = randint(8100, 9000)
+        # If metrics_port is not specified, we will use a random port between 8100 and 9000.
+        metrics_port = kwargs.get('metrics_port', randint(8100, 9000))
+        # Removing the port and metrics_port from kwargs to avoid passing them to the Flask app.
+        kwargs.pop('metrics_port', None)
+        # Starting the Cloudflared tunnel in a separate thread.
         thread = Timer(2, start_cloudflared, args=(port, metrics_port,))
         thread.setDaemon(True)
         thread.start()
+        # Running the Flask app.
         old_run(*args, **kwargs)
     app.run = new_run

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="flask_cloudflared",
-    version="0.0.11",
+    version="0.0.12",
     author="Ralf Rademacher",
     description="Start a TryCloudflare Tunnel from your flask app.",
     long_description=long_description,


### PR DESCRIPTION
This patch adds the option to set the metrics_port additionally to the flask port.
`app.run(port=1337, metrics_port=1338)` to set it to 1338, accessible at http://127.0.0.1:1338/metrics.